### PR TITLE
Add market and account functions with tests

### DIFF
--- a/tests/test_hyperliquid.py
+++ b/tests/test_hyperliquid.py
@@ -1,0 +1,66 @@
+import requests
+
+from trader.api import HyperLiquidAPI
+
+
+class DummyResponse:
+    def __init__(self, payload=None):
+        self.payload = payload or {}
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self.payload
+
+
+def test_fetch_eth_market_data_makes_get_request(monkeypatch):
+    called = {}
+
+    def mock_get(url, params=None):
+        called['url'] = url
+        called['params'] = params
+        return DummyResponse({'ok': True})
+
+    monkeypatch.setattr(requests, 'get', mock_get)
+
+    api = HyperLiquidAPI('https://api.test')
+    resp = api.fetch_eth_market_data()
+
+    assert resp == {'ok': True}
+    assert called['url'] == 'https://api.test/markets/ETH'
+
+
+def test_place_order_formatting(monkeypatch):
+    called = {}
+
+    def mock_post(url, json=None):
+        called['url'] = url
+        called['json'] = json
+        return DummyResponse({'order': 'ok'})
+
+    monkeypatch.setattr(requests, 'post', mock_post)
+
+    api = HyperLiquidAPI('https://api.test')
+    resp = api.place_order('ETH-USD', 1.5, 'buy')
+
+    assert resp == {'order': 'ok'}
+    assert called['url'] == 'https://api.test/orders'
+    assert called['json'] == {'symbol': 'ETH-USD', 'quantity': 1.5, 'side': 'buy'}
+
+
+def test_get_account_balances_makes_get_request(monkeypatch):
+    called = {}
+
+    def mock_get(url, params=None):
+        called['url'] = url
+        called['params'] = params
+        return DummyResponse({'balances': []})
+
+    monkeypatch.setattr(requests, 'get', mock_get)
+
+    api = HyperLiquidAPI('https://api.test')
+    resp = api.get_account_balances()
+
+    assert resp == {'balances': []}
+    assert called['url'] == 'https://api.test/balances'

--- a/trader/api/__init__.py
+++ b/trader/api/__init__.py
@@ -1,5 +1,5 @@
 """API wrappers for external services."""
 
-from .hyperliquid import HyperLiquidAPI
+from .hyperliquid import APIError, HyperLiquidAPI
 
-__all__ = ["HyperLiquidAPI"]
+__all__ = ["HyperLiquidAPI", "APIError"]

--- a/trader/api/hyperliquid.py
+++ b/trader/api/hyperliquid.py
@@ -3,6 +3,13 @@
 from typing import Any, Dict, Optional
 
 import requests
+from requests.exceptions import RequestException
+
+
+class APIError(Exception):
+    """Raised when the HyperLiquid API returns an error response."""
+
+    pass
 
 
 class HyperLiquidAPI:
@@ -14,7 +21,50 @@ class HyperLiquidAPI:
     def _url(self, path: str) -> str:
         return f"{self.base_url}{path}"
 
+    def get(
+        self, path: str, params: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Perform a GET request and return the parsed JSON response."""
+
+        try:
+            response = requests.get(self._url(path), params=params or {})
+            response.raise_for_status()
+        except RequestException as exc:  # pragma: no cover - network failure branch
+            raise ConnectionError(f"Failed to fetch {path}: {exc}") from exc
+
+        data = response.json()
+        if isinstance(data, dict) and data.get("error"):
+            raise APIError(data["error"])
+        return data
+
     def post(self, path: str, json: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-        response = requests.post(self._url(path), json=json or {})
-        response.raise_for_status()
-        return response.json()
+        """Perform a POST request and return the parsed JSON response."""
+
+        try:
+            response = requests.post(self._url(path), json=json or {})
+            response.raise_for_status()
+        except RequestException as exc:  # pragma: no cover - network failure branch
+            raise ConnectionError(f"Failed to fetch {path}: {exc}") from exc
+
+        data = response.json()
+        if isinstance(data, dict) and data.get("error"):
+            raise APIError(data["error"])
+        return data
+
+    # Convenience higher level helpers -----------------------------------------------------
+
+    def fetch_eth_market_data(self) -> Dict[str, Any]:
+        """Return market data for ETH."""
+
+        return self.get("/markets/ETH")
+
+    def place_order(self, symbol: str, quantity: float, side: str) -> Dict[str, Any]:
+        """Submit an order to the exchange."""
+
+        payload = {"symbol": symbol, "quantity": quantity, "side": side}
+        return self.post("/orders", json=payload)
+
+    def get_account_balances(self) -> Dict[str, Any]:
+        """Retrieve account balances."""
+
+        return self.get("/balances")


### PR DESCRIPTION
## Summary
- extend HyperLiquid API with error handling helpers
- expose `APIError` in `api.__init__`
- add unit tests for new API methods

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841833855d88328943fd176bcc8f8b7