### PR TITLE
Add strategy-based trading agent

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2,7 +2,7 @@ import types
 
 import pytest
 
-from trader import TradingAgent
+from trader import Agent, TradingAgent
 from trader.api import HyperLiquidAPI
 
 
@@ -14,6 +14,20 @@ class DummyAPI(HyperLiquidAPI):
         return {"path": path, "json": json}
 
 
+class AgentDummyAPI(HyperLiquidAPI):
+    def __init__(self, prices):
+        self.prices = list(prices)
+        self.orders = []
+
+    def fetch_eth_market_data(self):
+        return {"price": self.prices.pop(0)}
+
+    def place_order(self, symbol: str, quantity: float, side: str):
+        order = {"symbol": symbol, "quantity": quantity, "side": side}
+        self.orders.append(order)
+        return order
+
+
 def test_place_order_returns_response_dict():
     api = DummyAPI()
     agent = TradingAgent(api)
@@ -21,3 +35,19 @@ def test_place_order_returns_response_dict():
     assert isinstance(resp, dict)
     assert resp["path"] == "/orders"
     assert resp["json"]["symbol"] == "ETH-USD"
+
+
+def test_agent_moving_average_strategy():
+    prices = [100, 100, 100, 100, 100, 105, 110, 90, 80]
+    api = AgentDummyAPI(prices)
+    agent = Agent(
+        config={"symbol": "ETH", "quantity": 1.0, "short_window": 3, "long_window": 5},
+        api=api,
+    )
+
+    while api.prices:
+        agent.step()
+
+    assert len(api.orders) == 2
+    assert api.orders[0]["side"] == "buy"
+    assert api.orders[1]["side"] == "sell"

--- a/trader/__init__.py
+++ b/trader/__init__.py
@@ -1,5 +1,10 @@
 """Core trader package."""
 
-from .agent import TradingAgent
+from .agent import Agent, MovingAverageCrossStrategy, Strategy, TradingAgent
 
-__all__ = ["TradingAgent"]
+__all__ = [
+    "TradingAgent",
+    "Agent",
+    "Strategy",
+    "MovingAverageCrossStrategy",
+]

--- a/trader/agent.py
+++ b/trader/agent.py
@@ -1,6 +1,8 @@
-"""Main trading agent."""
+"""Trading agents and strategies."""
 
-from typing import Any, Dict
+import json
+from statistics import mean
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 
 from .api.hyperliquid import HyperLiquidAPI
 
@@ -33,3 +35,76 @@ class TradingAgent:
             "side": side,
         }
         return self.api.post("/orders", json=order_data)
+
+
+class Strategy:
+    """Trading strategy interface."""
+
+    def generate_signal(self, prices: Iterable[float]) -> str:
+        """Return ``'buy'``, ``'sell'`` or ``'hold'`` for the given prices."""
+
+        raise NotImplementedError
+
+
+class MovingAverageCrossStrategy(Strategy):
+    """Simple moving average crossover strategy."""
+
+    def __init__(self, short_window: int = 5, long_window: int = 20) -> None:
+        self.short_window = short_window
+        self.long_window = long_window
+        self._last_signal = "hold"
+
+    def generate_signal(self, prices: Iterable[float]) -> str:
+        prices = list(prices)
+        if len(prices) < self.long_window:
+            return "hold"
+
+        short_avg = mean(prices[-self.short_window :])
+        long_avg = mean(prices[-self.long_window :])
+
+        if short_avg > long_avg and self._last_signal != "buy":
+            self._last_signal = "buy"
+            return "buy"
+        if short_avg < long_avg and self._last_signal != "sell":
+            self._last_signal = "sell"
+            return "sell"
+        return "hold"
+
+
+class Agent:
+    """Trading agent that uses a strategy to decide when to trade."""
+
+    def __init__(
+        self,
+        config: Mapping[str, Any] | str,
+        api: Optional[HyperLiquidAPI] = None,
+        strategy: Optional[Strategy] = None,
+    ) -> None:
+        if isinstance(config, str):
+            with open(config, "r", encoding="utf-8") as fh:
+                config = json.load(fh)
+
+        self.config = dict(config)
+        base_url = self.config.get("base_url", "https://api.hyperliquid.xyz")
+        self.api = api or HyperLiquidAPI(base_url)
+
+        self.symbol = self.config.get("symbol", "ETH")
+        self.quantity = float(self.config.get("quantity", 1.0))
+
+        self.strategy = strategy or MovingAverageCrossStrategy(
+            short_window=int(self.config.get("short_window", 5)),
+            long_window=int(self.config.get("long_window", 20)),
+        )
+
+        self._prices: List[float] = []
+
+    def step(self) -> Optional[Dict[str, Any]]:
+        """Fetch market data, evaluate the strategy and place orders if needed."""
+
+        data = self.api.fetch_eth_market_data()
+        price = float(data.get("price"))
+        self._prices.append(price)
+        signal = self.strategy.generate_signal(self._prices)
+        if signal in {"buy", "sell"}:
+            return self.api.place_order(self.symbol, self.quantity, signal)
+        return None


### PR DESCRIPTION
## Summary
- implement `Strategy` interface with `MovingAverageCrossStrategy`
- add configurable `Agent` that loads settings and places orders
- export new classes in `trader.__init__`
- extend tests for new agent behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684183f17ce083289561e74b8204f5bb