### PR TITLE
Improve README with usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
+### Configure API keys
+
+Set your Hyperliquid credentials in the environment before running the
+agent:
+
+```bash
+export HYPERLIQUID_API_KEY="<your-api-key>"
+export HYPERLIQUID_API_SECRET="<your-api-secret>"
+```
+
+An example configuration file is provided in `config.example.json`. Copy it to
+`config.json` and adjust the values as needed.
+
 ## Usage
 
 Instantiate the `TradingAgent` with a configured `HyperLiquidAPI` instance and place orders programmatically:
@@ -25,6 +38,23 @@ agent = TradingAgent(api)
 response = agent.place_order("ETH-USD", quantity=1.0, side="buy")
 print(response)
 ```
+
+### Running the trading agent
+
+The repository includes an example configuration in `config.example.json`. To
+run the agent repeatedly using this configuration:
+
+```python
+from trader import Agent
+
+agent = Agent("config.json")
+while True:
+    agent.step()
+```
+
+Use the testnet API endpoint for paper trading and the main API for live
+trading. Simply set the `base_url` field in your configuration file
+accordingly.
 
 ## Testing
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,7 @@
+{
+  "base_url": "https://api.hyperliquid.xyz",
+  "symbol": "ETH",
+  "quantity": 1.0,
+  "short_window": 5,
+  "long_window": 20
+}


### PR DESCRIPTION
## Summary
- add example configuration file
- document Hyperliquid API key environment variables
- show how to run the agent in paper trading or live mode
- keep instructions for running unit tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418560e8c883288e36da18eb14bc2e